### PR TITLE
fix #49 : start decoding binary composite field from the offset position

### DIFF
--- a/src/main/java/com/solab/iso8583/codecs/CompositeField.java
+++ b/src/main/java/com/solab/iso8583/codecs/CompositeField.java
@@ -79,7 +79,7 @@ public class CompositeField implements CustomBinaryField<CompositeField> {
     public CompositeField decodeBinaryField(byte[] buf, int offset, int length) {
         @SuppressWarnings("rawtypes")
         List<IsoValue> vals = new ArrayList<>(parsers.size());
-        int pos = 0;
+        int pos = offset;
         try {
             for (FieldParseInfo fpi : parsers) {
                 IsoValue<?> v = fpi.parseBinary(0, buf, pos, fpi.getDecoder());

--- a/src/test/java/com/solab/iso8583/parse/TestComposites.java
+++ b/src/test/java/com/solab/iso8583/parse/TestComposites.java
@@ -79,4 +79,19 @@ public class TestComposites {
         Assert.assertEquals("X", f.getValues().get(3).getValue());
     }
 
+    @Test
+    public void testDecodeBinaryWithOffset() {
+        final CompositeField dec = new CompositeField()
+                .addParser(new LlvarParseInfo())
+                .addParser(new NumericParseInfo(5))
+                .addParser(new AlphaParseInfo(1));
+        int offset = 5;
+        final CompositeField f = dec.decodeBinaryField(binaryData, offset, this.binaryData.length - offset);
+        Assert.assertNotNull(f);
+        Assert.assertEquals(3, f.getValues().size());
+        Assert.assertEquals("Two", f.getValues().get(0).getValue());
+        Assert.assertEquals(999l, f.getValues().get(1).getValue());
+        Assert.assertEquals("X", f.getValues().get(2).getValue());
+    }
+
 }


### PR DESCRIPTION
I simply initialized the buffer position to the offset and added a unit test for this use case.