### PR TITLE
Feature pojo annotation config, alternative to XML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configurations {
 
 dependencies {
 	compile 'org.slf4j:slf4j-api:1.7.21'
+	compile 'commons-lang:commons-lang:2.6'
 	testCompile 'junit:junit:4.12'
 	testRuntime 'org.slf4j:slf4j-simple:1.7.21'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.j8583</groupId>
 	<artifactId>j8583</artifactId>
-	<version>1.10.2</version>
+	<version>1.12.0</version>
 	<packaging>jar</packaging>
 	<name>j8583</name>
 	<description>Java implementation of the ISO 8583 protocol, focused on making the creation, edition and reading of ISO8583 messages as simple and flexible as possible.</description>
@@ -27,13 +27,27 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
+			<version>1.7.21</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+	    <groupId>org.slf4j</groupId>
+	    <artifactId>slf4j-log4j12</artifactId>
+	    <version>1.7.21</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+	    <groupId>log4j</groupId>
+	    <artifactId>log4j</artifactId>
+	    <version>1.2.17</version>
+	    <optional>true</optional>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -60,10 +74,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.5</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.j8583</groupId>
 	<artifactId>j8583</artifactId>
-	<version>1.13.0-SNAPSHOT</version>
+	<version>1.13.0</version>
 	<packaging>jar</packaging>
 	<name>j8583</name>
 	<description>Java implementation of the ISO 8583 protocol, focused on making the creation, edition and reading of ISO8583 messages as simple and flexible as possible.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.j8583</groupId>
 	<artifactId>j8583</artifactId>
-	<version>1.12.0</version>
+	<version>1.13.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>j8583</name>
 	<description>Java implementation of the ISO 8583 protocol, focused on making the creation, edition and reading of ISO8583 messages as simple and flexible as possible.</description>
@@ -24,6 +24,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
+		<dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
 	</properties>
 	<dependencies>
 		<dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
     </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/src/main/java/com/solab/iso8583/IsoField.java
+++ b/src/main/java/com/solab/iso8583/IsoField.java
@@ -1,0 +1,406 @@
+/**
+ * IsoField
+ */
+package com.solab.iso8583;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+
+import com.solab.iso8583.annotation.Iso8583Field;
+
+/**
+ * Represents the definition of a field from a pojo annotated property
+ * @author lch
+ *
+ */
+public class IsoField<T extends Object> {
+
+	public static IsoField<Number> stan = new IsoField<Number>(11, "stan", IsoType.NUMERIC, 6, Number.class);
+	
+	/**
+	 * ISO 8583 index, unique per pojo 
+	 */
+	int index;
+	
+	/**
+	 * ISO 8583 field length
+	 */
+	int length = 0;
+
+	/**
+	 * ISO 8583 pojo {@link IsoType}
+	 */
+	IsoType isoType;
+
+	/**
+	 * Iso 8583 pojo field name
+	 */
+	String name;
+	
+	/**
+	 * real pojo property name holding the value
+	 */
+	String propertyName;
+	
+	/**
+	 * track the pojo field type
+	 * http://stackoverflow.com/questions/75175/create-instance-of-generic-type-in-java
+	 */
+	Class<T> fieldClass;
+
+	/**
+	 * @param index
+	 * @param name
+	 * @param isoType
+	 * @param length
+	 */
+	public IsoField(int index, String name, IsoType isoType, int length, Class<T> fieldClass) {
+		this.isoType = isoType;
+		this.length = length;
+		this.name = name;
+		this.index = index;
+		this.fieldClass = fieldClass;
+	}
+
+	/**
+	 * 
+	 * @param annotation pojo field annotated with {@link Iso8583Field}
+	 * @param fieldClass field type
+	 */
+	public IsoField(Iso8583Field annotation, Class<T> fieldClass) {
+		this(annotation.index(), annotation.name(), annotation.type(), annotation.length(), fieldClass);
+		switch (annotation.type()) {
+		case ALPHA:
+		case BINARY:
+		case NUMERIC:
+			if (length < 1) {
+				throw new IllegalArgumentException("length is not set correctly");
+			}
+			break;
+		default:
+		}
+		
+	}
+
+	/**
+	 * @return the index
+	 */
+	public int getIndex() {
+		return index;
+	}
+
+	/**
+	 * @param index the index to set
+	 * @return IsoField for convenience chaining
+	 */
+	public IsoField<T> setIndex(int index) {
+		this.index = index;
+		return this;
+	}
+
+	/**
+	 * @return the length
+	 */
+	public int getLength() {
+		return length;
+	}
+
+	/**
+	 * @param length the length to set
+	 * @return IsoField for convenience chaining
+	 */
+	public IsoField<T> setLength(int length) {
+		this.length = length;
+		return this;
+	}
+
+	/**
+	 * @return the isoType
+	 */
+	public IsoType getIsoType() {
+		return isoType;
+	}
+
+	/**
+	 * @param isoType the isoType to set
+	 * @return IsoField for convenience chaining
+	 */
+	public IsoField<T> setIsoType(IsoType isoType) {
+		this.isoType = isoType;
+		return this;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 * @return IsoField for convenience chaining
+	 */
+	public IsoField<T> setName(String name) {
+		this.name = name;
+		return this;
+	}
+
+	/**
+	 * @return the propertyName
+	 */
+	public String getPropertyName() {
+		return propertyName;
+	}
+	
+	/**
+	 * @param propertyName the propertyName to set
+	 */
+	public void setPropertyName(String propertyName) {
+		this.propertyName = propertyName;
+	}
+	
+	/**
+	 * used with pojo dynamic instantiation
+	 * @param value to cast to pojo field target type 
+	 * @return dynamically type of value from template pojo introspection
+	 * @throws ClassCastException
+	 */
+	public T getValueSafeCast(Object value) throws ClassCastException {
+		return fieldClass.cast(value);
+	}
+	
+	/**
+	 * used with pojo dynamic instantiation<br>
+	 * cast an IsoValue to pojo field target type
+	 * @param isoValue {@link IsoValue}
+	 * @return null if param null or IsoValue null
+	 * @throws ClassCastException
+	 */
+	@SuppressWarnings("unchecked")
+	public T getValueSafeCast(IsoValue<?> isoValue) throws ClassCastException {
+		if(null != isoValue){
+			if(null != isoValue.getEncoder()){
+				return (T) isoValue.getEncoder().decodeField(isoValue.getValue().toString());
+			}
+			if(isoValue.getType() == IsoType.NUMERIC)
+				return convertNumberToTargetClass((Number)isoValue.getValue(), fieldClass);
+			return fieldClass.cast(isoValue.getValue());
+		}
+		return null;
+	}
+
+	/**
+	 * Convert the given number into an instance of the given target class.
+	 * @param number the number to convert
+	 * @param targetClass the target class to convert to
+	 * @return the converted number
+	 * @throws IllegalArgumentException if the target class is not supported
+	 * (i.e. not a standard Number subclass as included in the JDK)
+	 * @see java.lang.Byte
+	 * @see java.lang.Short
+	 * @see java.lang.Integer
+	 * @see java.lang.Long
+	 * @see java.math.BigInteger
+	 * @see java.lang.Float
+	 * @see java.lang.Double
+	 * @see java.math.BigDecimal
+	 */
+	@SuppressWarnings({ "unchecked", "hiding" })
+	public <T> T convertNumberToTargetClass(Number number, Class<T> targetClass)
+			throws IllegalArgumentException {
+
+		assert null != number: "Number must not be null";
+		assert null != targetClass : "Target class must not be null";
+
+		if (targetClass.isInstance(number)) {
+			return (T) number;
+		}
+		else if (Byte.class == targetClass) {
+			byte value = number.byteValue();
+			if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Byte.valueOf(number.byteValue());
+		}
+		else if (Short.class == targetClass) {
+			short value = number.shortValue();
+			if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Short.valueOf(number.shortValue());
+		}
+		else if (Integer.class == targetClass) {
+			long value = number.intValue();
+			if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Integer.valueOf(number.intValue());
+		}
+		else if (Long.class == targetClass) {
+			long value = number.longValue();
+			return (T) Long.valueOf(value);
+		}
+		else if (BigInteger.class == targetClass) {
+			if (number instanceof BigDecimal) {
+				// do not lose precision - use BigDecimal's own conversion
+				return (T) ((BigDecimal) number).toBigInteger();
+			} else {
+				// original value is not a Big* number - use standard long conversion
+				return (T) BigInteger.valueOf(number.longValue());
+			}
+		}
+		else if (Float.class == targetClass) {
+			return (T) Float.valueOf(number.floatValue());
+		}
+		else if (Double.class == targetClass) {
+			return (T) Double.valueOf(number.doubleValue());
+		}
+		else if (BigDecimal.class == targetClass) {
+			// always use BigDecimal(String) here to avoid unpredictability of BigDecimal(double)
+			// (see BigDecimal javadoc for details)
+			return (T) new BigDecimal(number.toString());
+		}
+		else {
+			throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+		}
+	}
+	/**
+	 * @return the fieldClass
+	 */
+	public Class<T> getFieldClass() {
+		return fieldClass;
+	}
+
+	/**
+	 * @param fieldClass the fieldClass to set
+	 */
+	public void setFieldClass(Class<T> fieldClass) {
+		this.fieldClass = fieldClass;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + index;
+		result = prime * result + ((isoType == null) ? 0 : isoType.hashCode());
+		result = prime * result + length;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((propertyName == null) ? 0 : propertyName.hashCode());
+		result = prime * result + ((fieldClass == null) ? 0 : fieldClass.hashCode());
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		IsoField<?> other = (IsoField<?>) obj;
+		if (index != other.index)
+			return false;
+		if (isoType != other.isoType)
+			return false;
+		if (length != other.length)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (propertyName == null) {
+			if (other.propertyName != null)
+				return false;
+		} else if (!propertyName.equals(other.propertyName))
+			return false;
+		if (fieldClass == null) {
+			if (other.fieldClass != null)
+				return false;
+		} else if (!fieldClass.equals(other.fieldClass))
+			return false;
+		return true;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("IsoField [index=");
+		builder.append(index);
+		builder.append(", length=");
+		builder.append(length);
+		builder.append(", ");
+		if (isoType != null) {
+			builder.append("isoType=");
+			builder.append(isoType);
+			builder.append(", ");
+		}
+		if (name != null) {
+			builder.append("name=");
+			builder.append(name);
+			builder.append(", ");
+		}
+		if (propertyName != null) {
+			builder.append("propertyName=");
+			builder.append(propertyName);
+			builder.append(", ");
+		}
+		if (fieldClass != null) {
+			builder.append("fieldClass=");
+			builder.append(fieldClass);
+		}
+		builder.append("]");
+		return builder.toString();
+	}
+	
+	/**
+	 * pojo use, custom encoder/decoder to avoid during parsing a number 
+	 * which is handled by AlphaNumericFieldParseInfo return a String and not a Number 
+	 * @author dbs
+	 *
+	 */
+	public static class NumberCustomField implements CustomField<Number>{
+		@Override
+		public Number decodeField(String value) {
+			if(StringUtils.isNotBlank(value))
+				return NumberUtils.createNumber(value.replaceAll("\\D+", "").trim());
+			return null;
+		}
+		@Override
+		public String encodeField(Number value) {
+			if(null != value)
+				return value.toString();
+			return "";
+		}
+	}//class NumberCustomField 
+	
+	public static class AmountCustomField implements CustomField<Number>{
+		@Override
+		public Number decodeField(String value) {
+			if(StringUtils.isNotBlank(value))
+				return NumberUtils.createNumber(value.replaceAll("\\D+", "").trim());
+			return null;
+		}
+		@Override
+		public String encodeField(Number value) {
+			if(null != value)
+				return value.toString();
+			return "";
+		}
+	}//class NumberCustomField 
+}

--- a/src/main/java/com/solab/iso8583/IsoField.java
+++ b/src/main/java/com/solab/iso8583/IsoField.java
@@ -4,7 +4,6 @@
 package com.solab.iso8583;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/java/com/solab/iso8583/IsoField.java
+++ b/src/main/java/com/solab/iso8583/IsoField.java
@@ -377,8 +377,11 @@ public class IsoField<T extends Object> {
 	public static class NumberCustomField implements CustomField<Number>{
 		@Override
 		public Number decodeField(String value) {
-			if(StringUtils.isNotBlank(value))
-				return NumberUtils.createNumber(value.replaceAll("\\D+", "").trim());
+			if(StringUtils.isNotBlank(value)){
+				value = value.replaceAll("\\D+", "").trim();//rmove all non numeric chars
+				if(StringUtils.isNotBlank(value))//once more at it happens sometimes value sent is "null" as string or garbage
+					return NumberUtils.createNumber(value);
+			}
 			return null;
 		}
 		@Override

--- a/src/main/java/com/solab/iso8583/IsoMessage.java
+++ b/src/main/java/com/solab/iso8583/IsoMessage.java
@@ -25,7 +25,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /** Represents an ISO8583 message. This is the core class of the framework.
  * Contains the bitmap which is modified as fields are added/removed.
@@ -553,5 +555,20 @@ public class IsoMessage {
             }
         }
         return false;
+    }
+    
+    /**
+     * convenience to  retrieve all defined fields 
+     * @return array of fields currently defined
+     */
+    public Integer[] getAllFields() {
+    	Set<Integer> a = new HashSet<>(50); 
+    	for (int i = 0; i < fields.length; i++) {
+    		if (hasField(i)) {
+    			a.add(i);
+    		}
+			
+		}
+		return a.toArray(new Integer[a.size()]);
     }
 }

--- a/src/main/java/com/solab/iso8583/IsoMessage.java
+++ b/src/main/java/com/solab/iso8583/IsoMessage.java
@@ -562,13 +562,12 @@ public class IsoMessage {
      * @return array of fields currently defined
      */
     public Integer[] getAllFields() {
-    	Set<Integer> a = new HashSet<>(50); 
-    	for (int i = 0; i < fields.length; i++) {
-    		if (hasField(i)) {
-    			a.add(i);
-    		}
-			
-		}
-		return a.toArray(new Integer[a.size()]);
+    	  Set<Integer> a = new HashSet<>(50); 
+    	  for (int i = 0; i < fields.length; i++) {
+    		    if (hasField(i)) {
+    			      a.add(i);
+    		    }
+		    }
+		    return a.toArray(new Integer[a.size()]);
     }
 }

--- a/src/main/java/com/solab/iso8583/IsoValue.java
+++ b/src/main/java/com/solab/iso8583/IsoValue.java
@@ -59,7 +59,7 @@ public class IsoValue<T> implements Cloneable {
 	 */
 	public IsoValue(IsoType t, T value, CustomField<T> custom) {
 		if (t.needsLength()) {
-			throw new IllegalArgumentException("Fixed-value types must use constructor that specifies length");
+			throw new IllegalArgumentException(String.format("Fixed-value types %s must use constructor that specifies length", t != null ? t.name() : "unknown"));
 		}
 		encoder = custom;
 		type = t;
@@ -149,6 +149,40 @@ public class IsoValue<T> implements Cloneable {
                 }
 				length = custom == null ? ((byte[])val).length : custom.encodeField(value).length();
 			}
+			if (t == IsoType.LLBIN && length > 99) {
+				throw new IllegalArgumentException("LLBIN can only hold values up to 99 chars");
+			} else if (t == IsoType.LLLBIN && length > 999) {
+				throw new IllegalArgumentException("LLLBIN can only hold values up to 999 chars");
+            } else if (t == IsoType.LLLLBIN && length > 9999) {
+                throw new IllegalArgumentException("LLLLBIN can only hold values up to 9999 chars");
+			}
+		}
+	}
+
+	/**
+	 * For pojo parse definition we need only following parameters to make happy the parsing mechanism<br>
+	 * Kept as-is for XML backward compatibility<br>
+	 * We validate definition not the value as in XML<br>
+	 * Do NOT use this constructor for parsing
+	 * @param t {@link IsoType}
+	 * @param len field length
+	 * @param custom {@link CustomField}
+	 */
+	public IsoValue(IsoType t, int len, CustomField<T> custom) {
+		type = t;
+		length = len;
+		encoder = custom;
+		if (length == 0 && t.needsLength()) {
+			throw new IllegalArgumentException(String.format("Length must be greater than zero for type %s", t));
+		} else if (t == IsoType.LLVAR || t == IsoType.LLLVAR || t == IsoType.LLLLVAR) {
+			if (t == IsoType.LLVAR && length > 99) {
+				throw new IllegalArgumentException("LLVAR can only hold values up to 99 chars");
+			} else if (t == IsoType.LLLVAR && length > 999) {
+				throw new IllegalArgumentException("LLLVAR can only hold values up to 999 chars");
+            } else if (t == IsoType.LLLLVAR && length > 9999) {
+                throw new IllegalArgumentException("LLLLVAR can only hold values up to 9999 chars");
+			}
+		} else if (t == IsoType.LLBIN || t == IsoType.LLLBIN || t == IsoType.LLLLBIN) {
 			if (t == IsoType.LLBIN && length > 99) {
 				throw new IllegalArgumentException("LLBIN can only hold values up to 99 chars");
 			} else if (t == IsoType.LLLBIN && length > 999) {

--- a/src/main/java/com/solab/iso8583/MessageFactory.java
+++ b/src/main/java/com/solab/iso8583/MessageFactory.java
@@ -767,7 +767,7 @@ public class MessageFactory<T extends IsoMessage> {
 				templateType = ((Iso8583) annotation).type();
 				isoMessage = getMessageTemplate(templateType);
 			}
-			if (templateType == 0 || null == annotation || null == templateIsoFieldsMap) {
+			if (templateType == 0 || null == annotation || null == templateIsoFieldsMap || templateIsoFieldsMap.get(templateType) == null) {
 				// should happened only during hot debugging session
 				// warning to developer, see example in
 				// com.solab.iso8583.TestPojoIsoMessage#setup and others test

--- a/src/main/java/com/solab/iso8583/MessageFactory.java
+++ b/src/main/java/com/solab/iso8583/MessageFactory.java
@@ -731,7 +731,7 @@ public class MessageFactory<T extends IsoMessage> {
 	 *         annotated
 	 */
 	protected Map<Integer, IsoField<?>> setIsoPojoFields(final Class<?> clazz, T isoMessageTemplate) {
-		Field[] fields = clazz.getDeclaredFields();
+		Field[] fields = PojoUtils.getAllDeclaredFields(clazz);
 		Map<Integer, IsoField<?>> indexIsoFieldMap = new HashMap<>();
 		Iso8583Field iso8583Field;
 		for (Field field : fields) {
@@ -819,7 +819,7 @@ public class MessageFactory<T extends IsoMessage> {
 		case LLVAR:
 		case LLLVAR:
 			isoMessageTemplate.setField(fieldDef.index,
-					new IsoValue<String>(fieldDef.getIsoType(), fieldDef.getIsoType().getLength(), null));
+					new IsoValue<String>(fieldDef.getIsoType(), fieldDef.getLength(), null));
 			break;
 		case NUMERIC:
 			isoMessageTemplate.setField(fieldDef.getIndex(), new IsoValue<Number>(fieldDef.getIsoType(),
@@ -830,11 +830,11 @@ public class MessageFactory<T extends IsoMessage> {
 		case LLLBIN:
 		case LLLLBIN:
 			isoMessageTemplate.setField(fieldDef.index,
-					new IsoValue<Byte[]>(fieldDef.getIsoType(), fieldDef.getIsoType().getLength(), null));
+					new IsoValue<Byte[]>(fieldDef.getIsoType(), fieldDef.getLength(), null));
 			break;
 		default:
 			isoMessageTemplate.setField(fieldDef.index,
-					new IsoValue<>(fieldDef.getIsoType(), fieldDef.getIsoType().getLength(), null));
+					new IsoValue<>(fieldDef.getIsoType(), fieldDef.getLength() == 0 ? fieldDef.getIsoType().getLength() : fieldDef.getLength(), null));
 			break;
 		}
 		return isoMessageTemplate;

--- a/src/main/java/com/solab/iso8583/MessageFactory.java
+++ b/src/main/java/com/solab/iso8583/MessageFactory.java
@@ -975,6 +975,9 @@ public class MessageFactory<T extends IsoMessage> {
 							CompositeFieldPojo compositeField = (CompositeFieldPojo) objectCompositeField; 
 							Object customValue = isoField.getValueSafeCast(compositeField.getField(1));
 							PojoUtils.writeField(instance, isoField.getPropertyName(), isoField.getFieldClass(), customValue);
+						}else{
+							Object value = isoField.getValueSafeCast(isoValue);
+							PojoUtils.writeField(instance, propName, isoField.getFieldClass(), value);
 						}
 					} else if(isoField.isNested()){
 						Object objectCompositeField = isoMessage.getField(isoField.index).getEncoder();

--- a/src/main/java/com/solab/iso8583/annotation/Iso8583.java
+++ b/src/main/java/com/solab/iso8583/annotation/Iso8583.java
@@ -1,0 +1,56 @@
+package com.solab.iso8583.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.solab.iso8583.TraceNumberGenerator;
+import com.solab.iso8583.impl.SimpleTraceGenerator;
+
+/**
+ * Annotated to a pojo, this annotation defines an ISO 8583 template similar to XML definition 
+ * @author dbs
+ *@version 1.0
+ * @since V1.12.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Iso8583 {
+	
+	/**
+	 * mandatory, template number, in hexadecimal ie \"0x200\"
+	 */
+	int type();
+
+	/**
+	 * header to send, sent in binary if binary flag set
+	 */
+	String header() default "";
+
+	/**
+	 * flag to build a ISO 8583 in a binary form
+	 */
+	boolean binary() default false;
+	
+	/**
+	 * encoding for message template, default UTF-8   
+	 */
+	String encoding() default "UTF-8";
+	
+	//following would need to store per message template, currently at the factory level
+	/**
+	 * auto fill a system trace audit number  <code>11</code> if one is not already set. inapplicable for parsing 
+	 */
+	//boolean stan() default false;
+	
+	/**
+	 * generator to use, {@link #stan()} flag is activated 
+	 */
+	//Class<? extends TraceNumberGenerator> traceNumberGenerator() default SimpleTraceGenerator.class;
+	
+	/**
+	 * auto fill a date <code>7</code> if one is not already set. inapplicable for parsing
+	 */
+	//boolean date() default false;
+}

--- a/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
+++ b/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
@@ -34,7 +34,8 @@ public @interface Iso8583Field {
 	public IsoType type() default IsoType.ALPHA;
 
 	/**
-	 * used with {@link com.solab.iso8583.IsoType#NUMERIC}
+	 * used with {@link com.solab.iso8583.IsoType#NUMERIC}<br>
+	 * Do NOT set for other Iso type, except if will be a fixed length. validation will be made while parsing frames
 	 */
 	public int length() default 0;
 	

--- a/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
+++ b/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
@@ -1,0 +1,39 @@
+package com.solab.iso8583.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.solab.iso8583.IsoType;
+
+/**
+ * Annotation to decorate pojo fields which must be part of a ISO 8583 template definition
+ * @author dbs on Sep 24, 2016
+ * @version 1.0
+ * @since V1.12.0
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Iso8583Field {
+	/**
+	 * mandatory, unique index for a pojo template
+	 */
+	public int index();
+	
+	/**
+	 * if empty the pojo field name will be used
+	 */
+	public String name() default "";
+	
+	/**
+	 * default is {@link com.solab.iso8583.IsoType#ALPHA}
+	 */
+	public IsoType type() default IsoType.ALPHA;
+
+	/**
+	 * used with {@link com.solab.iso8583.IsoType#NUMERIC}
+	 */
+	public int length() default 0;
+	
+}

--- a/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
+++ b/src/main/java/com/solab/iso8583/annotation/Iso8583Field.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.solab.iso8583.CustomBinaryField;
+import com.solab.iso8583.IsoField.DefaultCustomStringField;
 import com.solab.iso8583.IsoType;
 
 /**
@@ -35,5 +37,25 @@ public @interface Iso8583Field {
 	 * used with {@link com.solab.iso8583.IsoType#NUMERIC}
 	 */
 	public int length() default 0;
+	
+	/**
+	 * flag to indicate if a field will be an other object to introspect to retrieve encoded private fields<br>
+	 * Not applicable for primitive objects
+	 * incompatible with {@link #customField()}
+	 */
+	public boolean nestedField() default false;
+	
+	/**
+	 *  flag to indicate if a field will be handled by a {@link CustomField} encoder/decoder
+	 *  {@link #customFieldMapper()} will be used to handle the fields<br>
+	 *  cannot be set with {@link #nestedField()}
+	 */
+	public boolean customField() default false;
+	
+	/**
+	 * if {@link #customField()} is set, define a {@link CustomField} encoder/decoder here<br>
+	 * ignored if {@link #nestedField()} is set to true
+	 */
+	Class<? extends CustomBinaryField<?>> customFieldMapper() default DefaultCustomStringField.class;
 	
 }

--- a/src/main/java/com/solab/iso8583/annotation/package-info.java
+++ b/src/main/java/com/solab/iso8583/annotation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * annotations declarations for introspection ISO8583 definition detection
+ * @author dbs
+ *
+ */
+package com.solab.iso8583.annotation;

--- a/src/main/java/com/solab/iso8583/parse/ConfigParser.java
+++ b/src/main/java/com/solab/iso8583/parse/ConfigParser.java
@@ -514,7 +514,6 @@ public class ConfigParser {
 						combo.addParser(getParser(isoValue2, mfact));
 					}
 				}
-			}else{
 			}
 			fieldParseInfo = getParser(isoValue, mfact);
 			parseMap.put(indexField, fieldParseInfo);

--- a/src/main/java/com/solab/iso8583/util/PojoUtils.java
+++ b/src/main/java/com/solab/iso8583/util/PojoUtils.java
@@ -176,7 +176,7 @@ public class PojoUtils {
 	 * @param classParameterizedType target
 	 * @return true 
 	 */
-	public static boolean isAssignable(final Class<?> parameterizedClass, final Class<?> classParameterizedType) {
+	public static boolean isParameterizedAssignable(final Class<?> parameterizedClass, final Class<?> classParameterizedType) {
 		ParameterizedType parameterizedType = extractParameterizedTypeFromInterface(parameterizedClass);
 		if (parameterizedType == null) {
 			//Class and any of its interfaces are not parameterized
@@ -215,6 +215,17 @@ public class PojoUtils {
 			}
 		}
 		return null;
+	}
+	
+	/**
+	 * wrapper around {@link TypeUtils#isAssignable(Type, Type)}<br>
+	 * to avoid non necessary imports
+	 * @param type the subject type to be assigned to the target type
+     * @param toType the target type
+     * @return {@code true} if {@code type} is assignable to {@code toType}.
+	 */
+	public static boolean isAssignable(final Class<?> type, final Class<?> toType) {
+		return TypeUtils.isAssignable(type, toType);
 	}
 	
 	/**

--- a/src/main/java/com/solab/iso8583/util/PojoUtils.java
+++ b/src/main/java/com/solab/iso8583/util/PojoUtils.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -213,5 +215,81 @@ public class PojoUtils {
 			}
 		}
 		return null;
+	}
+	
+	/**
+	 * Convert the given number into an instance of the given target class.
+	 * @param number the number to convert
+	 * @param targetClass the target class to convert to
+	 * @return the converted number
+	 * @throws IllegalArgumentException if the target class is not supported
+	 * (i.e. not a standard Number subclass as included in the JDK)
+	 * @see java.lang.Byte
+	 * @see java.lang.Short
+	 * @see java.lang.Integer
+	 * @see java.lang.Long
+	 * @see java.math.BigInteger
+	 * @see java.lang.Float
+	 * @see java.lang.Double
+	 * @see java.math.BigDecimal
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public static <T> T convertNumberToTargetClass(Number number, Class<T> targetClass)
+			throws IllegalArgumentException {
+
+		assert null != number: "Number must not be null";
+		assert null != targetClass : "Target class must not be null";
+
+		if (targetClass.isInstance(number)) {
+			return (T) number;
+		}
+		else if (Byte.class == targetClass) {
+			byte value = number.byteValue();
+			if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Byte.valueOf(number.byteValue());
+		}
+		else if (Short.class == targetClass) {
+			short value = number.shortValue();
+			if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Short.valueOf(number.shortValue());
+		}
+		else if (Integer.class == targetClass) {
+			long value = number.intValue();
+			if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+				throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+			}
+			return (T) Integer.valueOf(number.intValue());
+		}
+		else if (Long.class == targetClass) {
+			long value = number.longValue();
+			return (T) Long.valueOf(value);
+		}
+		else if (BigInteger.class == targetClass) {
+			if (number instanceof BigDecimal) {
+				// do not lose precision - use BigDecimal's own conversion
+				return (T) ((BigDecimal) number).toBigInteger();
+			} else {
+				// original value is not a Big* number - use standard long conversion
+				return (T) BigInteger.valueOf(number.longValue());
+			}
+		}
+		else if (Float.class == targetClass) {
+			return (T) Float.valueOf(number.floatValue());
+		}
+		else if (Double.class == targetClass) {
+			return (T) Double.valueOf(number.doubleValue());
+		}
+		else if (BigDecimal.class == targetClass) {
+			// always use BigDecimal(String) here to avoid unpredictability of BigDecimal(double)
+			// (see BigDecimal javadoc for details)
+			return (T) new BigDecimal(number.toString());
+		}
+		else {
+			throw new IllegalArgumentException(String.format("Could not convert number [%d] of type [%s] to target class [%s]: overflow", number, number.getClass().getName(), targetClass.getName()));
+		}
 	}
 }

--- a/src/main/java/com/solab/iso8583/util/PojoUtils.java
+++ b/src/main/java/com/solab/iso8583/util/PojoUtils.java
@@ -1,0 +1,147 @@
+/**
+ * PojoUtils
+ */
+package com.solab.iso8583.util;
+
+import java.lang.ref.Reference;
+import java.lang.ref.SoftReference;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+
+/**
+ * Simple utility class for working with the reflection API<br>
+ * Wrapper to Apache reflection utilities<br> 
+ * this implementation add cache mechanism
+ * Inspiration from Spring Core utilities<br>
+ * @author dbs on Sep 24, 2016 8:36:21 AM
+ * @version 1.0
+ * @since V1.12.0
+ *
+ */
+public class PojoUtils {
+
+  /**
+   * initial default size Fields cache (256) 
+   */
+  protected static int declaredFieldsCacheSize = 256;
+  
+  /**
+   * Cache for {@link Class#getDeclaredFields()}, allowing for fast iteration.
+   */
+  private static Map<Class<?>, Reference<Field[]>> declaredFieldsCache = 
+      Collections.synchronizedMap(new WeakHashMap<Class<?>, Reference<Field[]>>(declaredFieldsCacheSize));
+  
+  /**
+   * Attempt to find a {@link Field field} on the supplied {@link Class} with the
+   * supplied {@code name} and/or {@link Class type}. Searches all superclasses
+   * up to {@link Object}.<br>
+   * Make the field explicitly accessible if necessary
+   * @param clazz the class to introspect
+   * @param name the name of the field (may be {@code null} if type is specified)
+   * @param type the type of the field (may be {@code null} if name is specified)
+   * @return the corresponding Field object, or {@code null} if not found
+   */
+  protected static Field findField(Class<? extends Object> clazz, String name, Class<?> type) {
+    Class<?> searchType = clazz;
+    while (Object.class != searchType && searchType != null) {
+      Field[] fields = getDeclaredFields(searchType);
+      for (Field field : fields) {
+        if ((name == null || name.equals(field.getName())) &&
+            (type == null || type.equals(field.getType()))) {
+          
+          if ((!Modifier.isPublic(field.getModifiers()) ||
+              !Modifier.isPublic(field.getDeclaringClass().getModifiers()) ||
+              Modifier.isFinal(field.getModifiers())) && !field.isAccessible()) {
+            field.setAccessible(true);
+          }
+          return field;
+        }
+      }
+      searchType = searchType.getSuperclass();
+    }
+    return null;
+  }
+
+  /**
+   * Read a field from a pojo instance<br>
+   * Call effectively {@link FieldUtils#readField(Field, Object, boolean)} after caching the field
+   * @param instance pojo instance
+   * @param propName field name to read
+   * @param type field target class to read
+   * @return the field value
+   * @throws IllegalArgumentException
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T readField(Object instance, String propName, Class<T> type) throws IllegalArgumentException {
+    T value = null;
+    try {
+      Field field = findField(instance.getClass(), propName, type);
+      value = (T) FieldUtils.readField(field, instance, true);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Failed to read value for property [%s]", propName), e);
+    }
+    return value;
+  }
+  
+  /**
+   * 
+   * @param instance pojo instance
+   * @param propName field name to set
+   * @param type field target class to set
+   * @param value the value to set
+   * @throws IllegalArgumentException
+   */
+  public static <T> void writeField(Object instance, String propName, Class<T> type, Object value) throws IllegalArgumentException {
+    try {
+      Field field = findField(instance.getClass(), propName, type);
+      FieldUtils.writeField(field, instance, value, true);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Failed to read value for property [%s]", propName), e);
+    }
+  }
+
+	/**
+	 * This variant retrieves {@link Class#getDeclaredFields()} from a local cache
+	 * in order to avoid the JVM's SecurityManager check and defensive array copying.
+	 * @param clazz the class to introspect
+	 * @return the cached array of fields
+	 * @see Class#getDeclaredFields()
+	 */
+	protected static Field[] getDeclaredFields(Class<?> clazz) {
+		Reference<Field[]> ref = declaredFieldsCache.get(clazz);
+		if(null != ref && ref.get() != null)
+			return ref.get();
+		Field[] result = clazz.getDeclaredFields();
+		ref = new SoftReference<Field[]>(result.length == 0 ? new Field[]{} : result);
+		declaredFieldsCache.put(clazz, ref);
+		return result;
+	}
+
+  /**
+   * @return the declaredFieldsCacheSize
+   */
+  public static int getDeclaredFieldsCacheSize() {
+    return declaredFieldsCacheSize;
+  }
+
+  /**
+   * setter to change size of Fields cache<br>
+   * Rebuild the map if cache size changes 
+   * @param declaredFieldsCacheSizeNew the declaredFieldsCacheSize to set
+   */
+  public static void setDeclaredFieldsCacheSize(int declaredFieldsCacheSizeNew) {
+    if(declaredFieldsCacheSize != declaredFieldsCacheSizeNew){
+      declaredFieldsCacheSize = declaredFieldsCacheSizeNew;
+      declaredFieldsCache.clear();
+      declaredFieldsCache = null;//force GC notice
+      declaredFieldsCache = 
+          Collections.synchronizedMap(new WeakHashMap<Class<?>, Reference<Field[]>>(declaredFieldsCacheSize));
+    }
+  }
+
+}

--- a/src/main/java/com/solab/iso8583/util/PojoUtils.java
+++ b/src/main/java/com/solab/iso8583/util/PojoUtils.java
@@ -8,9 +8,12 @@ import java.lang.ref.SoftReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.reflect.FieldUtils;
 
 /**
@@ -122,6 +125,22 @@ public class PojoUtils {
 		return result;
 	}
 
+	/**
+	 * This variant retrieves {@link Class#getDeclaredFields()} from a local cache
+	 * in order to avoid the JVM's SecurityManager check and defensive array copying.
+	 * @param clazz the class to introspect
+	 * @return the cached array of fields
+	 * @see #getDeclaredFields(Class)
+	 */
+	public static Field[] getAllDeclaredFields(Class<?> clazz) {
+		Field[] fields = new Field[0];
+		Class<?> searchType = clazz;
+    while (Object.class != searchType && searchType != null) {
+    	fields = (Field[]) ArrayUtils.addAll(fields, getDeclaredFields(searchType));
+    	searchType = searchType.getSuperclass();
+    }
+    return fields;
+	}
   /**
    * @return the declaredFieldsCacheSize
    */

--- a/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
@@ -1,0 +1,413 @@
+package com.solab.iso8583.pojo;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoField.DefaultCustomStringField;
+import com.solab.iso8583.annotation.Iso8583Field;
+
+/**
+ * copied from http://j8583.sourceforge.net/xmlconf.html<br>
+ * field name comes from https://github.com/kpavlov/jreactive-8583/blob/master/src/main/resources/org/jreactive/iso8583/iso8583fields.properties
+ * 
+ * @author dilbertside on Sep 29, 2016
+ * @since 1.13.0
+ * @version 1.0.0
+ *
+ */
+@SuppressWarnings("serial")
+public class AbstractMessage implements Serializable{
+
+	
+	public static class PrivateData implements Serializable{
+		
+		private static final long serialVersionUID = 5863255007081836317L;
+
+		@Iso8583Field(index=1, type=IsoType.ALPHA, length=40)
+  	protected String privateDataStr = "Life, the Universe, and Everything";
+  	
+  	@Iso8583Field(index=2, type=IsoType.NUMERIC, length=2)
+  	protected Number privateDataNum = 42;
+
+  	public PrivateData(){}
+  	
+		/**
+		 * @param privateDataStr
+		 * @param privateDataNum
+		 */
+		public PrivateData(PrivateData toClone) {
+			this.privateDataStr = toClone.privateDataStr;
+			this.privateDataNum = toClone.privateDataNum;
+		}
+		
+		/* (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this);
+		}
+		/* (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object obj) {
+			return EqualsBuilder.reflectionEquals(this, obj);
+		}
+		/* (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
+
+		/**
+		 * @return the privateDataStr
+		 */
+		public String getPrivateDataStr() {
+			return privateDataStr;
+		}
+
+		/**
+		 * @param privateDataStr the privateDataStr to set
+		 * @return AbstractMessage.PrivateData for convenience chaining
+		 */
+		public PrivateData setPrivateDataStr(String privateDataStr) {
+			this.privateDataStr = privateDataStr;
+			return this;
+		}
+
+		/**
+		 * @return the privateDataNum
+		 */
+		public Number getPrivateDataNum() {
+			return privateDataNum;
+		}
+
+		/**
+		 * @param privateDataNum the privateDataNum to set
+		 * @return AbstractMessage.PrivateData for convenience chaining
+		 */
+		public PrivateData setPrivateDataNum(Number privateDataNum) {
+			this.privateDataNum = privateDataNum;
+			return this;
+		}
+  	
+  }
+
+		
+	@Iso8583Field(index=3, type=IsoType.NUMERIC, length=6)
+	protected Integer processingCode = 650000;
+	
+	@Iso8583Field(index=7, type=IsoType.DATE10)
+	protected Date dateTransaction = new GregorianCalendar(2000, 1, 1, 1 ,1, 1).getTime();
+	
+	@Iso8583Field(index=11, type=IsoType.NUMERIC, length=6)
+	protected Number systemTraceAuditNumber = 999999;
+
+	@Iso8583Field(index=28, type=IsoType.AMOUNT)
+    protected BigDecimal amountTransactionFee = BigDecimal.TEN;
+		
+	@Iso8583Field(index=32, type=IsoType.LLVAR)
+    protected String acquiringInstitutionIdentificationCode= "456";
+    
+    @Iso8583Field(index=35, type=IsoType.LLVAR)
+    protected String track2Data = "4591700012340000=";
+    
+    //Card acceptor name/location (1-23 address 24-36 city 37-38 state 39-40 country)
+    @Iso8583Field(index=43, type=IsoType.ALPHA, length=40)
+    protected String cardAcceptorName= "Fixed-width data";
+    
+    //national
+    @Iso8583Field(index=47, type=IsoType.LLLVAR, length=999, customField=true, customFieldMapper= DefaultCustomStringField.class)
+    protected String additionalDataNational;
+    
+    //private
+    @Iso8583Field(index=48, type=IsoType.LLLVAR, length=999, nestedField=true)
+    protected PrivateData additionalData = new PrivateData();
+    
+    @Iso8583Field(index=49, type=IsoType.ALPHA, length=3)
+    protected String currencyCodeTransaction= "840";
+    
+    @Iso8583Field(index=60, type=IsoType.LLLVAR)
+    protected String reservedNational = "B456PRO1+000";
+    
+    @Iso8583Field(index=61, type=IsoType.LLLVAR)
+    protected String reservedPrivate = "This field can have a value up to 999 characters long.";
+    
+    @Iso8583Field(index=100, type=IsoType.LLVAR)
+    protected String receivingInstitutionIdentificationCode= "999";
+    
+    @Iso8583Field(index=102, type=IsoType.LLVAR)
+    protected String accountIdentification1= "ABCD";
+    
+    public AbstractMessage() {}
+
+		public AbstractMessage(AbstractMessage toClone) {
+			this.processingCode = toClone.processingCode;
+			this.acquiringInstitutionIdentificationCode = toClone.acquiringInstitutionIdentificationCode;
+			this.track2Data = toClone.track2Data;
+			this.cardAcceptorName = toClone.cardAcceptorName;
+			this.additionalData = toClone.additionalData;
+			this.currencyCodeTransaction = toClone.currencyCodeTransaction;
+			this.reservedNational = toClone.reservedNational;
+			this.reservedPrivate = toClone.reservedPrivate;
+			this.receivingInstitutionIdentificationCode = toClone.receivingInstitutionIdentificationCode;
+			this.accountIdentification1 = toClone.accountIdentification1;
+		}
+
+
+		/**
+		 * @return the processingCode
+		 */
+		public Integer getProcessingCode() {
+			return processingCode;
+		}
+
+		/**
+		 * @param processingCode the processingCode to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setProcessingCode(Integer processingCode) {
+			this.processingCode = processingCode;
+			return this;
+		}
+
+		/**
+		 * @return the acquiringInstitutionIdentificationCode
+		 */
+		public String getAcquiringInstitutionIdentificationCode() {
+			return acquiringInstitutionIdentificationCode;
+		}
+
+		/**
+		 * @param acquiringInstitutionIdentificationCode the acquiringInstitutionIdentificationCode to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setAcquiringInstitutionIdentificationCode(String acquiringInstitutionIdentificationCode) {
+			this.acquiringInstitutionIdentificationCode = acquiringInstitutionIdentificationCode;
+			return this;
+		}
+
+		/**
+		 * @return the track2Data
+		 */
+		public String getTrack2Data() {
+			return track2Data;
+		}
+
+		/**
+		 * @param track2Data the track2Data to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setTrack2Data(String track2Data) {
+			this.track2Data = track2Data;
+			return this;
+		}
+
+		/**
+		 * @return the cardAcceptorName
+		 */
+		public String getCardAcceptorName() {
+			return cardAcceptorName;
+		}
+
+		/**
+		 * @param cardAcceptorName the cardAcceptorName to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setCardAcceptorName(String cardAcceptorName) {
+			this.cardAcceptorName = cardAcceptorName;
+			return this;
+		}
+
+		/**
+		 * @return the additionalData
+		 */
+		public PrivateData getAdditionalData() {
+			return additionalData;
+		}
+
+		/**
+		 * @param additionalData the additionalData to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setAdditionalData(PrivateData additionalData) {
+			this.additionalData = additionalData;
+			return this;
+		}
+
+		/**
+		 * @return the currencyCodeTransaction
+		 */
+		public String getCurrencyCodeTransaction() {
+			return currencyCodeTransaction;
+		}
+
+		/**
+		 * @param currencyCodeTransaction the currencyCodeTransaction to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setCurrencyCodeTransaction(String currencyCodeTransaction) {
+			this.currencyCodeTransaction = currencyCodeTransaction;
+			return this;
+		}
+
+		/**
+		 * @return the reservedNational
+		 */
+		public String getReservedNational() {
+			return reservedNational;
+		}
+
+		/**
+		 * @param reservedNational the reservedNational to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setReservedNational(String reservedNational) {
+			this.reservedNational = reservedNational;
+			return this;
+		}
+
+		/**
+		 * @return the reservedPrivate
+		 */
+		public String getReservedPrivate() {
+			return reservedPrivate;
+		}
+
+		/**
+		 * @param reservedPrivate the reservedPrivate to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setReservedPrivate(String reservedPrivate) {
+			this.reservedPrivate = reservedPrivate;
+			return this;
+		}
+
+		/**
+		 * @return the receivingInstitutionIdentificationCode
+		 */
+		public String getReceivingInstitutionIdentificationCode() {
+			return receivingInstitutionIdentificationCode;
+		}
+
+		/**
+		 * @param receivingInstitutionIdentificationCode the receivingInstitutionIdentificationCode to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setReceivingInstitutionIdentificationCode(String receivingInstitutionIdentificationCode) {
+			this.receivingInstitutionIdentificationCode = receivingInstitutionIdentificationCode;
+			return this;
+		}
+
+		/**
+		 * @return the accountIdentification1
+		 */
+		public String getAccountIdentification1() {
+			return accountIdentification1;
+		}
+
+		/**
+		 * @param accountIdentification1 the accountIdentification1 to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setAccountIdentification1(String accountIdentification1) {
+			this.accountIdentification1 = accountIdentification1;
+			return this;
+		}
+		
+		/* (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this);
+		}
+		/* (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object obj) {
+			return EqualsBuilder.reflectionEquals(this, obj);
+		}
+		/* (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
+
+		/**
+		 * @return the dateTransaction
+		 */
+		public Date getDateTransaction() {
+			return dateTransaction;
+		}
+
+		/**
+		 * @param dateTransaction the dateTransaction to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setDateTransaction(Date dateTransaction) {
+			this.dateTransaction = dateTransaction;
+			return this;
+		}
+
+		/**
+		 * @return the systemTraceAuditNumber
+		 */
+		public Number getSystemTraceAuditNumber() {
+			return systemTraceAuditNumber;
+		}
+
+		/**
+		 * @param systemTraceAuditNumber the systemTraceAuditNumber to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setSystemTraceAuditNumber(Number systemTraceAuditNumber) {
+			this.systemTraceAuditNumber = systemTraceAuditNumber;
+			return this;
+		}
+
+		/**
+		 * @return the amountTransactionFee
+		 */
+		public BigDecimal getAmountTransactionFee() {
+			return amountTransactionFee;
+		}
+
+		/**
+		 * @param amountTransactionFee the amountTransactionFee to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setAmountTransactionFee(BigDecimal amountTransactionFee) {
+			this.amountTransactionFee = amountTransactionFee;
+			return this;
+		}
+
+		/**
+		 * @return the additionalDataNational
+		 */
+		public String getAdditionalDataNational() {
+			return additionalDataNational;
+		}
+
+		/**
+		 * @param additionalDataNational the additionalDataNational to set
+		 * @return AbstractMessage for convenience chaining
+		 */
+		public AbstractMessage setAdditionalDataNational(String additionalDataNational) {
+			this.additionalDataNational = additionalDataNational;
+			return this;
+		}
+}

--- a/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
@@ -124,14 +124,14 @@ public class AbstractMessage implements Serializable{
     
     //Card acceptor name/location (1-23 address 24-36 city 37-38 state 39-40 country)
     @Iso8583Field(index=43, type=IsoType.ALPHA, length=40)
-    protected String cardAcceptorName= "Fixed-width data";
+    protected String cardAcceptorName= "Fixed-width data                        ";
     
     //national
-    @Iso8583Field(index=47, type=IsoType.LLLVAR, length=999, customField=true, customFieldMapper= DefaultCustomStringField.class)
+    @Iso8583Field(index=47, type=IsoType.LLLVAR, customField=true, customFieldMapper= DefaultCustomStringField.class)
     protected String additionalDataNational;
     
     //private
-    @Iso8583Field(index=48, type=IsoType.LLLVAR, length=999, nestedField=true)
+    @Iso8583Field(index=48, type=IsoType.LLLVAR, nestedField=true)
     protected PrivateData additionalData = new PrivateData();
     
     @Iso8583Field(index=49, type=IsoType.ALPHA, length=3)

--- a/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/AbstractMessage.java
@@ -144,7 +144,7 @@ public class AbstractMessage implements Serializable{
 		}
 		
 		public String toString(){
-			return getLabel();
+			return "" + getCode();
 		}
 
 	}
@@ -166,7 +166,7 @@ public class AbstractMessage implements Serializable{
 		
 		@Override
 		public String encodeField(ProcessingCode value) {
-			return new StringBuilder(value.code).toString();
+			return value.toString();
 		}
 
 		@Override
@@ -180,7 +180,7 @@ public class AbstractMessage implements Serializable{
 		}
 	}
 	
-	@Iso8583Field(index=3, type=IsoType.NUMERIC, length=6, customField = true, customFieldMapper=EnumProcessingCodeCustomField.class)
+	@Iso8583Field(index=3, type=IsoType.NUMERIC, length=4, customField = true, customFieldMapper=EnumProcessingCodeCustomField.class)
 	protected ProcessingCode processingCode = ProcessingCode.yes;
 	
 	@Iso8583Field(index=7, type=IsoType.DATE10)

--- a/src/test/java/com/solab/iso8583/pojo/AcquirerFinancialRequest.java
+++ b/src/test/java/com/solab/iso8583/pojo/AcquirerFinancialRequest.java
@@ -1,0 +1,30 @@
+/**
+ * AcquirerFinancialRequest
+ */
+package com.solab.iso8583.pojo;
+
+import com.solab.iso8583.annotation.Iso8583;
+
+/**
+ * @author dilbertside on Sep 29, 2016 9:41:18 AM
+ * @since 1.13.0
+ * @version 1.0.0
+ *
+ */
+@Iso8583(type=0x200)
+public class AcquirerFinancialRequest extends AbstractMessage {
+
+	private static final long serialVersionUID = -4352711673146090451L;
+
+	public AcquirerFinancialRequest() { 
+		super();
+	}
+
+	/**
+	 * @param toClone
+	 */
+	public AcquirerFinancialRequest(AbstractMessage toClone) {
+		super(toClone);
+	}
+
+}

--- a/src/test/java/com/solab/iso8583/pojo/NetworkMgmtRequest.java
+++ b/src/test/java/com/solab/iso8583/pojo/NetworkMgmtRequest.java
@@ -1,0 +1,147 @@
+package com.solab.iso8583.pojo;
+
+import java.util.Date;
+
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.annotation.*;
+
+@Iso8583(type=0x800)
+public class NetworkMgmtRequest {
+	
+	protected String bogus;
+	
+	@Iso8583Field(index=7, type=IsoType.DATE10)
+	protected Date dateTransaction;
+	
+	@Iso8583Field(index=11, type=IsoType.NUMERIC, length=6)
+	protected Number systemTraceAuditNumber;
+	
+	
+	@Iso8583Field(index=70, type=IsoType.NUMERIC, length=3)
+	protected Number codeInformationNetwork;
+
+	/**
+	 * newInstance requires an empty pojo constructor
+	 */
+	public NetworkMgmtRequest(){
+		
+	}
+	/**
+	 * @param dateTransaction
+	 * @param systemTraceAuditNumber
+	 * @param codeInformationNetwork
+	 */
+	public NetworkMgmtRequest(Date dateTransaction, Number systemTraceAuditNumber, Number codeInformationNetwork) {
+		this.dateTransaction = dateTransaction;
+		this.systemTraceAuditNumber = systemTraceAuditNumber;
+		this.codeInformationNetwork = codeInformationNetwork;
+	}
+
+	/**
+	 * @return the dateTransaction
+	 */
+	public Date getDateTransaction() {
+		return dateTransaction;
+	}
+
+
+	/**
+	 * @param dateTransaction the dateTransaction to set
+	 */
+	public void setDateTransaction(Date dateTransaction) {
+		this.dateTransaction = dateTransaction;
+	}
+
+
+	/**
+	 * @return the systemTraceAuditNumber
+	 */
+	public Number getSystemTraceAuditNumber() {
+		return systemTraceAuditNumber;
+	}
+
+
+	/**
+	 * @param systemTraceAuditNumber the systemTraceAuditNumber to set
+	 */
+	public void setSystemTraceAuditNumber(Number systemTraceAuditNumber) {
+		this.systemTraceAuditNumber = systemTraceAuditNumber;
+	}
+
+
+	/**
+	 * @return the codeInformationNetwork
+	 */
+	public Number getCodeInformationNetwork() {
+		return codeInformationNetwork;
+	}
+
+
+	/**
+	 * @param codeInformationNetwork the codeInformationNetwork to set
+	 */
+	public void setCodeInformationNetwork(Number codeInformationNetwork) {
+		this.codeInformationNetwork = codeInformationNetwork;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((bogus == null) ? 0 : bogus.hashCode());
+		result = prime * result + ((codeInformationNetwork == null) ? 0 : codeInformationNetwork.hashCode());
+		result = prime * result + ((dateTransaction == null) ? 0 : dateTransaction.hashCode());
+		result = prime * result + ((systemTraceAuditNumber == null) ? 0 : systemTraceAuditNumber.hashCode());
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		NetworkMgmtRequest other = (NetworkMgmtRequest) obj;
+		if (bogus == null) {
+			if (other.bogus != null)
+				return false;
+		} else if (!bogus.equals(other.bogus))
+			return false;
+		if (codeInformationNetwork == null) {
+			if (other.codeInformationNetwork != null)
+				return false;
+		} else if (!codeInformationNetwork.equals(other.codeInformationNetwork))
+			return false;
+		if (dateTransaction == null) {
+			if (other.dateTransaction != null)
+				return false;
+		} else if (!dateTransaction.equals(other.dateTransaction))
+			return false;
+		if (systemTraceAuditNumber == null) {
+			if (other.systemTraceAuditNumber != null)
+				return false;
+		} else if (!systemTraceAuditNumber.equals(other.systemTraceAuditNumber))
+			return false;
+		return true;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "NetworkMgmtRequest [bogus=" + bogus + ", dateTransaction=" + dateTransaction
+				+ ", systemTraceAuditNumber=" + systemTraceAuditNumber + ", codeInformationNetwork="
+				+ codeInformationNetwork + "]";
+	}
+	
+	
+}

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -194,9 +194,10 @@ public class TestPojoIsoMessage {
 	    
 	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(47).getType());
 	    log.debug("nested pojo\n {}", iso.getObjectValue(47));
-	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(47) instanceof CompositeFieldPojo);
-	    CompositeFieldPojo cf = iso.getObjectValue(47);
-	    Assert.assertEquals(request.getAdditionalDataNational(), cf.getField(1).getValue());
+	    //Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(47) instanceof CompositeFieldPojo);
+	    //CompositeFieldPojo cf = iso.getObjectValue(47);
+	    //Assert.assertEquals(request.getAdditionalDataNational(), cf.getField(1).getValue());
+	    Assert.assertEquals(request.getAdditionalDataNational(), iso.getObjectValue(47));
 	    
 	    //here we go the nested pojo
 	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(48).getType());

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -1,0 +1,140 @@
+/**
+ * TestPojoIsoMessage
+ */
+package com.solab.iso8583.pojo;
+
+import static org.junit.Assert.*;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.solab.iso8583.IsoMessage;
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.MessageFactory;
+import com.solab.iso8583.impl.SimpleTraceGenerator;
+import com.solab.iso8583.parse.ConfigParser;
+
+/**
+ * @author dilbertside
+ *
+ */
+@SuppressWarnings("deprecation")
+public class TestPojoIsoMessage {
+
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+	private MessageFactory<IsoMessage> mf;
+	
+	NetworkMgmtRequest request;
+	Date dateTransaction = new GregorianCalendar(2000, 1, 1, 1 ,1, 1).getTime();
+	Number systemTraceAuditNumber = 999999;
+	Number codeInformationNetwork = 1;
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		mf = ConfigParser.createFromPojo(NetworkMgmtRequest.class);
+		mf.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		mf.setUseBinaryMessages(false);
+		mf.setAssignDate(true);
+		request = new NetworkMgmtRequest(dateTransaction, systemTraceAuditNumber, codeInformationNetwork);
+	}
+
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 */
+	@Test
+	public void testNewMessage() {
+		IsoMessage iso = mf.newMessage(request);
+		Assert.assertEquals(0x800, iso.getType());
+        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+        Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+		
+        log.debug("testNewMessage\n {}", iso.debugString());
+	}
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 */
+	@Test
+	public void testNewMessageAutoStan() {
+		mf.setTraceNumberGenerator(new SimpleTraceGenerator(20));
+		request.setSystemTraceAuditNumber(null);
+		IsoMessage iso = mf.newMessage(request);
+		Assert.assertEquals(0x800, iso.getType());
+        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+        
+        Assert.assertEquals(20, iso.getObjectValue(11));
+        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+        Date dt = iso.getObjectValue(7);
+        Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+        Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+        Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+        Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+        Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+        
+        
+        log.debug("testNewMessageAutoStan\n {}", iso.debugString());
+        
+        mf.setTraceNumberGenerator(null);
+	}
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 * @throws ParseException 
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testRoundTrip() throws UnsupportedEncodingException, ParseException  {
+		//encode
+		IsoMessage iso = mf.newMessage(request);
+		Assert.assertEquals(0x800, iso.getType());
+        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+        Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+        Date dt = iso.getObjectValue(7);
+        Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+        Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+        Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+        Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+        Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+        
+        String isoStr = iso.debugString();
+        log.debug("testRoundTrip\n {}", isoStr);
+        
+        //decode
+        IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
+		NetworkMgmtRequest nmr = mf.parseMessage(m, NetworkMgmtRequest.class);
+		Assert.assertEquals(request.getCodeInformationNetwork(), nmr.getCodeInformationNetwork());
+        Assert.assertEquals(request.getDateTransaction().getMonth(), nmr.getDateTransaction().getMonth());
+        //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
+        nmr.getDateTransaction().setYear(request.getDateTransaction().getYear());
+        Assert.assertEquals(request.getDateTransaction().getDay(), nmr.getDateTransaction().getDay());
+        Assert.assertEquals(request.getDateTransaction().getHours(), nmr.getDateTransaction().getHours());
+        Assert.assertEquals(request.getDateTransaction().getMinutes(), nmr.getDateTransaction().getMinutes());
+        Assert.assertEquals(request.getDateTransaction().getSeconds(), nmr.getDateTransaction().getSeconds());
+		Assert.assertEquals(request.getSystemTraceAuditNumber(), nmr.getSystemTraceAuditNumber());
+	}
+
+}

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -31,7 +31,7 @@ import com.solab.iso8583.parse.ConfigParser;
  * @author dilbertside
  *
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({ "deprecation", "unused" })
 public class TestPojoIsoMessage {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
@@ -46,7 +46,7 @@ public class TestPojoIsoMessage {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		mf = ConfigParser.createFromPojo(NetworkMgmtRequest.class);
+		mf = ConfigParser.createFromPojo(NetworkMgmtRequest.class, AcquirerFinancialRequest.class);
 		mf.setCharacterEncoding(StandardCharsets.UTF_8.name());
 		mf.setUseBinaryMessages(false);
 		mf.setAssignDate(true);
@@ -60,14 +60,14 @@ public class TestPojoIsoMessage {
 	public void testNewMessage() {
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-        Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
-        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-		
-        log.debug("testNewMessage\n {}", iso.debugString());
+    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+
+    log.debug("testNewMessage\n {}", iso.debugString());
 	}
 	
 	/**
@@ -79,24 +79,24 @@ public class TestPojoIsoMessage {
 		request.setSystemTraceAuditNumber(null);
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-        
-        Assert.assertEquals(20, iso.getObjectValue(11));
-        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-        Date dt = iso.getObjectValue(7);
-        Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
-        Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
-        Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
-        Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
-        Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
-        
-        
-        log.debug("testNewMessageAutoStan\n {}", iso.debugString());
-        
-        mf.setTraceNumberGenerator(null);
+    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+    
+    Assert.assertEquals(20, iso.getObjectValue(11));
+    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+    Date dt = iso.getObjectValue(7);
+    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+    
+    
+    log.debug("testNewMessageAutoStan\n {}", iso.debugString());
+    
+    mf.setTraceNumberGenerator(null);
 	}
 	
 	/**
@@ -109,33 +109,33 @@ public class TestPojoIsoMessage {
 		//encode
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-        Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-        Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-        Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-        Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
-        Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-        Date dt = iso.getObjectValue(7);
-        Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
-        Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
-        Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
-        Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
-        Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
-        
-        String isoStr = iso.debugString();
-        log.debug("testRoundTrip\n {}", isoStr);
-        
-        //decode
-        IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
+    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+    Date dt = iso.getObjectValue(7);
+    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+    
+    String isoStr = iso.debugString();
+    log.debug("testRoundTrip\n {}", isoStr);
+    
+    //decode
+    IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
 		NetworkMgmtRequest nmr = mf.parseMessage(m, NetworkMgmtRequest.class);
 		Assert.assertEquals(request.getCodeInformationNetwork(), nmr.getCodeInformationNetwork());
-        Assert.assertEquals(request.getDateTransaction().getMonth(), nmr.getDateTransaction().getMonth());
-        //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
-        nmr.getDateTransaction().setYear(request.getDateTransaction().getYear());
-        Assert.assertEquals(request.getDateTransaction().getDay(), nmr.getDateTransaction().getDay());
-        Assert.assertEquals(request.getDateTransaction().getHours(), nmr.getDateTransaction().getHours());
-        Assert.assertEquals(request.getDateTransaction().getMinutes(), nmr.getDateTransaction().getMinutes());
-        Assert.assertEquals(request.getDateTransaction().getSeconds(), nmr.getDateTransaction().getSeconds());
+    Assert.assertEquals(request.getDateTransaction().getMonth(), nmr.getDateTransaction().getMonth());
+    //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
+    nmr.getDateTransaction().setYear(request.getDateTransaction().getYear());
+    Assert.assertEquals(request.getDateTransaction().getDay(), nmr.getDateTransaction().getDay());
+    Assert.assertEquals(request.getDateTransaction().getHours(), nmr.getDateTransaction().getHours());
+    Assert.assertEquals(request.getDateTransaction().getMinutes(), nmr.getDateTransaction().getMinutes());
+    Assert.assertEquals(request.getDateTransaction().getSeconds(), nmr.getDateTransaction().getSeconds());
 		Assert.assertEquals(request.getSystemTraceAuditNumber(), nmr.getSystemTraceAuditNumber());
 	}
 
@@ -151,5 +151,70 @@ public class TestPojoIsoMessage {
 	@Test(expected=IllegalArgumentException.class)
 	public void testNewMessageNotRegistered(){
 		mf.newMessage(new NotRegisteredPojo());
+	}
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 */
+	@Test
+	public void testNewMessageAcquirerFinancialRequest() {
+		AcquirerFinancialRequest request = new AcquirerFinancialRequest();
+		request.setSystemTraceAuditNumber(systemTraceAuditNumber);
+		request.setReservedNational("hello world!");
+		//make it!!
+		IsoMessage iso = mf.newMessage(request);
+		
+		Assert.assertEquals(0x200, iso.getType());
+	    Assert.assertTrue(iso.hasEveryField(3,7,11,28,32,35,43,47,48,49,60,61,100,102));
+	    
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(3).getType());
+	    Assert.assertEquals(request.getProcessingCode(), iso.getObjectValue(3));
+	    
+	    //IsoType.DATE10 is year insensitive
+	    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+	    Date dt = (Date) iso.getField(7).getValue(); dt.setYear(2000);
+	    Assert.assertEquals(request.getDateTransaction(), dt);
+	    
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+	    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+	    
+	    //check acquiringInstitutionIdentificationCode
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(32).getType());
+	    Assert.assertEquals(request.getAcquiringInstitutionIdentificationCode(), iso.getObjectValue(32));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(35).getType());
+	    Assert.assertEquals(request.getTrack2Data(), iso.getObjectValue(35));
+	    
+	    Assert.assertEquals(IsoType.ALPHA, iso.getField(43).getType());
+	    Assert.assertEquals(request.getCardAcceptorName(), iso.getObjectValue(43));
+	    
+	    //here we go the nested pojo
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(48).getType());
+	    log.debug("nested pojo\n {}", iso.getObjectValue(48));
+	    //Assert.assertEquals(request.getAdditionalData(), iso.getObjectValue(48));
+	    
+	    Assert.assertEquals(IsoType.ALPHA, iso.getField(49).getType());
+	    Assert.assertEquals(request.getCurrencyCodeTransaction(), iso.getObjectValue(49));
+	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(60).getType());
+	    Assert.assertEquals(request.getReservedNational(), iso.getObjectValue(60));
+	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(61).getType());
+	    Assert.assertEquals(request.getReservedPrivate(), iso.getObjectValue(61));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(100).getType());
+	    Assert.assertEquals(request.getReceivingInstitutionIdentificationCode(), iso.getObjectValue(100));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(102).getType());
+	    Assert.assertEquals(request.getAccountIdentification1(), iso.getObjectValue(102));
+	    
+	    /*Assert.assertEquals(IsoType., iso.getField().getType());
+	    Assert.assertEquals(request.get, iso.getObjectValue());*/
+	    
+	    
+	    //Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+	    //here we are very interested if our nested field was set 
+	
+	    log.debug("testNewMessageAcquirerFinancialRequest\n {}", iso.debugString());
 	}
 }

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.solab.iso8583.IsoField.CompositeFieldPojo;
 import com.solab.iso8583.IsoMessage;
 import com.solab.iso8583.IsoType;
 import com.solab.iso8583.MessageFactory;
@@ -60,14 +61,14 @@ public class TestPojoIsoMessage {
 	public void testNewMessage() {
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
-    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-
-    log.debug("testNewMessage\n {}", iso.debugString());
+	    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+	    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+	    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+	    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+	
+	    log.debug("testNewMessage\n {}", iso.debugString());
 	}
 	
 	/**
@@ -79,24 +80,24 @@ public class TestPojoIsoMessage {
 		request.setSystemTraceAuditNumber(null);
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-    
-    Assert.assertEquals(20, iso.getObjectValue(11));
-    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-    Date dt = iso.getObjectValue(7);
-    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
-    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
-    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
-    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
-    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
-    
-    
-    log.debug("testNewMessageAutoStan\n {}", iso.debugString());
-    
-    mf.setTraceNumberGenerator(null);
+	    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+	    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+	    
+	    Assert.assertEquals(20, iso.getObjectValue(11));
+	    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+	    Date dt = iso.getObjectValue(7);
+	    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+	    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+	    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+	    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+	    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+	    
+	    
+	    log.debug("testNewMessageAutoStan\n {}", iso.debugString());
+	    
+	    mf.setTraceNumberGenerator(null);
 	}
 	
 	/**
@@ -109,33 +110,33 @@ public class TestPojoIsoMessage {
 		//encode
 		IsoMessage iso = mf.newMessage(request);
 		Assert.assertEquals(0x800, iso.getType());
-    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
-    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
-    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
-    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
-    Date dt = iso.getObjectValue(7);
-    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
-    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
-    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
-    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
-    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
-    
-    String isoStr = iso.debugString();
-    log.debug("testRoundTrip\n {}", isoStr);
-    
-    //decode
-    IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
+	    Assert.assertTrue(iso.hasEveryField(7, 11, 70));
+	    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
+	    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+	    Assert.assertEquals(codeInformationNetwork, iso.getObjectValue(70));
+	    Date dt = iso.getObjectValue(7);
+	    Assert.assertEquals(dateTransaction.getMonth(), dt.getMonth());
+	    Assert.assertEquals(dateTransaction.getDay(), dt.getDay());
+	    Assert.assertEquals(dateTransaction.getHours(), dt.getHours());
+	    Assert.assertEquals(dateTransaction.getMinutes(), dt.getMinutes());
+	    Assert.assertEquals(dateTransaction.getSeconds(), dt.getSeconds());
+	    
+	    String isoStr = iso.debugString();
+	    log.debug("testRoundTrip\n {}", isoStr);
+	    
+	    //decode
+	    IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
 		NetworkMgmtRequest nmr = mf.parseMessage(m, NetworkMgmtRequest.class);
 		Assert.assertEquals(request.getCodeInformationNetwork(), nmr.getCodeInformationNetwork());
-    Assert.assertEquals(request.getDateTransaction().getMonth(), nmr.getDateTransaction().getMonth());
-    //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
-    nmr.getDateTransaction().setYear(request.getDateTransaction().getYear());
-    Assert.assertEquals(request.getDateTransaction().getDay(), nmr.getDateTransaction().getDay());
-    Assert.assertEquals(request.getDateTransaction().getHours(), nmr.getDateTransaction().getHours());
-    Assert.assertEquals(request.getDateTransaction().getMinutes(), nmr.getDateTransaction().getMinutes());
-    Assert.assertEquals(request.getDateTransaction().getSeconds(), nmr.getDateTransaction().getSeconds());
+	    Assert.assertEquals(request.getDateTransaction().getMonth(), nmr.getDateTransaction().getMonth());
+	    //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
+	    nmr.getDateTransaction().setYear(request.getDateTransaction().getYear());
+	    Assert.assertEquals(request.getDateTransaction().getDay(), nmr.getDateTransaction().getDay());
+	    Assert.assertEquals(request.getDateTransaction().getHours(), nmr.getDateTransaction().getHours());
+	    Assert.assertEquals(request.getDateTransaction().getMinutes(), nmr.getDateTransaction().getMinutes());
+	    Assert.assertEquals(request.getDateTransaction().getSeconds(), nmr.getDateTransaction().getSeconds());
 		Assert.assertEquals(request.getSystemTraceAuditNumber(), nmr.getSystemTraceAuditNumber());
 	}
 
@@ -160,7 +161,8 @@ public class TestPojoIsoMessage {
 	public void testNewMessageAcquirerFinancialRequest() {
 		AcquirerFinancialRequest request = new AcquirerFinancialRequest();
 		request.setSystemTraceAuditNumber(systemTraceAuditNumber);
-		request.setReservedNational("hello world!");
+		//request.setReservedNational("hello world!");
+		request.setAdditionalDataNational("AdditionalDataNational!");
 		//make it!!
 		IsoMessage iso = mf.newMessage(request);
 		
@@ -178,7 +180,9 @@ public class TestPojoIsoMessage {
 	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
 	    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
 	    
-	    //check acquiringInstitutionIdentificationCode
+	    Assert.assertEquals(IsoType.AMOUNT, iso.getField(28).getType());
+	    Assert.assertEquals(request.getAmountTransactionFee(), iso.getObjectValue(28));
+	    
 	    Assert.assertEquals(IsoType.LLVAR, iso.getField(32).getType());
 	    Assert.assertEquals(request.getAcquiringInstitutionIdentificationCode(), iso.getObjectValue(32));
 	    
@@ -188,10 +192,19 @@ public class TestPojoIsoMessage {
 	    Assert.assertEquals(IsoType.ALPHA, iso.getField(43).getType());
 	    Assert.assertEquals(request.getCardAcceptorName(), iso.getObjectValue(43));
 	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(47).getType());
+	    log.debug("nested pojo\n {}", iso.getObjectValue(47));
+	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(47) instanceof CompositeFieldPojo);
+	    CompositeFieldPojo cf = iso.getObjectValue(47);
+	    Assert.assertEquals(request.getAdditionalDataNational(), cf.getField(1).getValue());
+	    
 	    //here we go the nested pojo
 	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(48).getType());
 	    log.debug("nested pojo\n {}", iso.getObjectValue(48));
-	    //Assert.assertEquals(request.getAdditionalData(), iso.getObjectValue(48));
+	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(48) instanceof CompositeFieldPojo);
+	    CompositeFieldPojo cf1 = iso.getObjectValue(48);
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataStr(), cf1.getField(1).getValue());
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataNum(), cf1.getField(2).getValue());
 	    
 	    Assert.assertEquals(IsoType.ALPHA, iso.getField(49).getType());
 	    Assert.assertEquals(request.getCurrencyCodeTransaction(), iso.getObjectValue(49));
@@ -208,13 +221,136 @@ public class TestPojoIsoMessage {
 	    Assert.assertEquals(IsoType.LLVAR, iso.getField(102).getType());
 	    Assert.assertEquals(request.getAccountIdentification1(), iso.getObjectValue(102));
 	    
-	    /*Assert.assertEquals(IsoType., iso.getField().getType());
-	    Assert.assertEquals(request.get, iso.getObjectValue());*/
-	    
-	    
-	    //Assert.assertEquals(IsoType.NUMERIC, iso.getField(70).getType());
-	    //here we are very interested if our nested field was set 
-	
 	    log.debug("testNewMessageAcquirerFinancialRequest\n {}", iso.debugString());
+	}
+	
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 * Test method for {@link com.solab.iso8583.MessageFactory#parseMessage(IsoMessage, Class)}.
+	 * @throws ParseException 
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testNewMessageAcquirerFinancialRequestRoundTrip() throws UnsupportedEncodingException, ParseException {
+		AcquirerFinancialRequest request = new AcquirerFinancialRequest();
+		request.setSystemTraceAuditNumber(systemTraceAuditNumber);
+		//request.setReservedNational("hello world!");
+		request.setAdditionalDataNational("AdditionalDataNational!");
+		//make it!!
+		IsoMessage iso = mf.newMessage(request);
+		
+		Assert.assertEquals(0x200, iso.getType());
+	    Assert.assertTrue(iso.hasEveryField(3,7,11,28,32,35,43,47,48,49,60,61,100,102));
+	    
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(3).getType());
+	    Assert.assertEquals(request.getProcessingCode(), iso.getObjectValue(3));
+	    
+	    //IsoType.DATE10 is year insensitive
+	    Assert.assertEquals(IsoType.DATE10, iso.getField(7).getType());
+	    Date dt = (Date) iso.getField(7).getValue(); dt.setYear(2000);
+	    Assert.assertEquals(request.getDateTransaction(), dt);
+	    
+	    Assert.assertEquals(IsoType.NUMERIC, iso.getField(11).getType());
+	    Assert.assertEquals(systemTraceAuditNumber, iso.getObjectValue(11));
+	    
+	    Assert.assertEquals(IsoType.AMOUNT, iso.getField(28).getType());
+	    Assert.assertEquals(request.getAmountTransactionFee(), iso.getObjectValue(28));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(32).getType());
+	    Assert.assertEquals(request.getAcquiringInstitutionIdentificationCode(), iso.getObjectValue(32));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(35).getType());
+	    Assert.assertEquals(request.getTrack2Data(), iso.getObjectValue(35));
+	    
+	    Assert.assertEquals(IsoType.ALPHA, iso.getField(43).getType());
+	    Assert.assertEquals(request.getCardAcceptorName(), iso.getObjectValue(43));
+	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(47).getType());
+	    log.debug("nested pojo\n {}", iso.getObjectValue(47));
+	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(47) instanceof CompositeFieldPojo);
+	    CompositeFieldPojo cf = iso.getObjectValue(47);
+	    Assert.assertEquals(request.getAdditionalDataNational(), cf.getField(1).getValue());
+	    
+	    //here we go the nested pojo
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(48).getType());
+	    log.debug("nested pojo\n {}", iso.getObjectValue(48));
+	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(48) instanceof CompositeFieldPojo);
+	    CompositeFieldPojo cf1 = iso.getObjectValue(48);
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataStr(), cf1.getField(1).getValue());
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataNum(), cf1.getField(2).getValue());
+	    
+	    Assert.assertEquals(IsoType.ALPHA, iso.getField(49).getType());
+	    Assert.assertEquals(request.getCurrencyCodeTransaction(), iso.getObjectValue(49));
+	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(60).getType());
+	    Assert.assertEquals(request.getReservedNational(), iso.getObjectValue(60));
+	    
+	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(61).getType());
+	    Assert.assertEquals(request.getReservedPrivate(), iso.getObjectValue(61));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(100).getType());
+	    Assert.assertEquals(request.getReceivingInstitutionIdentificationCode(), iso.getObjectValue(100));
+	    
+	    Assert.assertEquals(IsoType.LLVAR, iso.getField(102).getType());
+	    Assert.assertEquals(request.getAccountIdentification1(), iso.getObjectValue(102));
+	    
+	    String isoStr = iso.debugString();
+	    log.debug("testNewMessageAcquirerFinancialRequestRoundTrip\n {}", isoStr);
+	    
+	    //decode here, second leg of the round trip
+	    IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
+	    AcquirerFinancialRequest afr = mf.parseMessage(m, AcquirerFinancialRequest.class);
+	    
+		// field 3
+	    Assert.assertEquals(request.getProcessingCode(), afr.getProcessingCode());
+
+	    // field 7
+	    Assert.assertEquals(request.getDateTransaction().getMonth(), afr.getDateTransaction().getMonth());
+	    //IsoType.DATE10 is year insensitive, we need to set the year otherwise week day number will be wrong
+	    afr.getDateTransaction().setYear(request.getDateTransaction().getYear());
+	    Assert.assertEquals(request.getDateTransaction().getDay(), afr.getDateTransaction().getDay());
+	    Assert.assertEquals(request.getDateTransaction().getHours(), afr.getDateTransaction().getHours());
+	    Assert.assertEquals(request.getDateTransaction().getMinutes(), afr.getDateTransaction().getMinutes());
+	    Assert.assertEquals(request.getDateTransaction().getSeconds(), afr.getDateTransaction().getSeconds());
+		
+	    // field 11
+	    Assert.assertEquals(request.getSystemTraceAuditNumber(), afr.getSystemTraceAuditNumber());
+		
+	    // field 28
+	    Assert.assertEquals(request.getAmountTransactionFee().longValue(), afr.getAmountTransactionFee().longValue());
+	    
+	    // field 32
+	    Assert.assertEquals(request.getAcquiringInstitutionIdentificationCode(), afr.getAcquiringInstitutionIdentificationCode());
+	    
+	    // field 35
+	    Assert.assertEquals(request.getTrack2Data(), afr.getTrack2Data());
+	    
+	    // field 43
+	    Assert.assertEquals(request.getCardAcceptorName(), afr.getCardAcceptorName());
+	    
+	    // field 47
+	    Assert.assertEquals(request.getAdditionalDataNational(), afr.getAdditionalDataNational());
+	    
+	    // field 48
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataStr(), afr.getAdditionalData().getPrivateDataStr());
+	    Assert.assertEquals(request.getAdditionalData().getPrivateDataNum(), afr.getAdditionalData().getPrivateDataNum());
+	    
+	    // field 49
+	    Assert.assertEquals(request.getCurrencyCodeTransaction(), afr.getCurrencyCodeTransaction());
+	    
+	    // field 60
+	    Assert.assertEquals(request.getReservedNational(), afr.getReservedNational());
+	    
+	    // field 61
+	    Assert.assertEquals(request.getReservedPrivate(), afr.getReservedPrivate());
+	    
+	    // field 100
+	    Assert.assertEquals(request.getReceivingInstitutionIdentificationCode(), afr.getReceivingInstitutionIdentificationCode());
+	    
+	    // field 102
+	    Assert.assertEquals(request.getAccountIdentification1(), afr.getAccountIdentification1());
+	    
+	    
 	}
 }

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -27,6 +27,7 @@ import com.solab.iso8583.annotation.Iso8583;
 import com.solab.iso8583.annotation.Iso8583Field;
 import com.solab.iso8583.impl.SimpleTraceGenerator;
 import com.solab.iso8583.parse.ConfigParser;
+import com.solab.iso8583.pojo.AbstractMessage.ProcessingCode;
 
 /**
  * @author dilbertside
@@ -235,6 +236,7 @@ public class TestPojoIsoMessage {
 	@Test
 	public void testNewMessageAcquirerFinancialRequestRoundTrip() throws UnsupportedEncodingException, ParseException {
 		AcquirerFinancialRequest request = new AcquirerFinancialRequest();
+		request.setProcessingCode(ProcessingCode.maybe);
 		request.setSystemTraceAuditNumber(systemTraceAuditNumber);
 		//request.setReservedNational("hello world!");
 		request.setAdditionalDataNational("AdditionalDataNational!");
@@ -268,10 +270,7 @@ public class TestPojoIsoMessage {
 	    Assert.assertEquals(request.getCardAcceptorName(), iso.getObjectValue(43));
 	    
 	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(47).getType());
-	    log.debug("nested pojo\n {}", iso.getObjectValue(47));
-	    Assert.assertTrue("must be of type CompositeFieldPojo", iso.getObjectValue(47) instanceof CompositeFieldPojo);
-	    CompositeFieldPojo cf = iso.getObjectValue(47);
-	    Assert.assertEquals(request.getAdditionalDataNational(), cf.getField(1).getValue());
+	    Assert.assertEquals(request.getAdditionalDataNational(), iso.getObjectValue(47));
 	    
 	    //here we go the nested pojo
 	    Assert.assertEquals(IsoType.LLLVAR, iso.getField(48).getType());

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoIsoMessage.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import com.solab.iso8583.IsoMessage;
 import com.solab.iso8583.IsoType;
 import com.solab.iso8583.MessageFactory;
+import com.solab.iso8583.annotation.Iso8583;
+import com.solab.iso8583.annotation.Iso8583Field;
 import com.solab.iso8583.impl.SimpleTraceGenerator;
 import com.solab.iso8583.parse.ConfigParser;
 
@@ -137,4 +139,17 @@ public class TestPojoIsoMessage {
 		Assert.assertEquals(request.getSystemTraceAuditNumber(), nmr.getSystemTraceAuditNumber());
 	}
 
+	@Iso8583(type=0x200)
+	public static class NotRegisteredPojo{
+		@Iso8583Field(index=70, type=IsoType.NUMERIC, length=3)
+		public Number codeInformationNetwork;
+	}
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#newMessage(Object)}.
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testNewMessageNotRegistered(){
+		mf.newMessage(new NotRegisteredPojo());
+	}
 }

--- a/src/test/java/com/solab/iso8583/pojo/TestPojoParsing.java
+++ b/src/test/java/com/solab/iso8583/pojo/TestPojoParsing.java
@@ -1,0 +1,56 @@
+/**
+ * TestParsingPojo
+ */
+package com.solab.iso8583.pojo;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.solab.iso8583.IsoMessage;
+import com.solab.iso8583.MessageFactory;
+import com.solab.iso8583.parse.ConfigParser;
+
+/**
+ * @author dilbertside on Sep 24, 2016
+ * @version 1.0
+ * @since V1.12.0
+ *
+ */
+public class TestPojoParsing {
+
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+	private MessageFactory<IsoMessage> mf;
+
+	@Before
+	public void init() throws IOException {
+		mf = ConfigParser.createFromPojo(NetworkMgmtRequest.class);
+		mf.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		mf.setUseBinaryMessages(false);
+		mf.setAssignDate(true);
+	}
+
+	@Test(expected=ParseException.class)
+	public void testEmpty() throws ParseException, UnsupportedEncodingException {
+		mf.parseMessage(new byte[0], 0);
+		IsoMessage m = mf.parseMessage("060002000000000000000125213456".getBytes(), 0);
+	}
+	
+	/**
+	 * Test method for {@link com.solab.iso8583.MessageFactory#parseMessage(com.solab.iso8583.IsoMessage, java.lang.Class)}.
+	 */
+	@Test
+	public void testPojoParse() throws ParseException, UnsupportedEncodingException {
+		String isoStr = "0800822000000000000004000000000000000922115010999999001";
+		IsoMessage m = mf.parseMessage(isoStr.getBytes(), 0);
+		NetworkMgmtRequest networkMgmtRequest = mf.parseMessage(m, NetworkMgmtRequest.class);
+		
+		log.debug("testPojoParse\n{}\n {}", isoStr, networkMgmtRequest.toString());
+	}
+}


### PR DESCRIPTION
Hi,

### Objective

I propose an alternative way to configure your library by not writing an XML config file.
In short, I propose a configuration like Jackson does it for JSON.
It removes the hassle to template the ISO 8583 message in XML.
Creating and parsing an ISO message is made par introspection, and a field cache mechanism was implemented to avoid java introspection for repeated calls to same pojo fields.

Having a pojo is beneficial for several reasons:
* transforming ISO85883 to JSON can be made in the same pojo, by adding Jackson annotations
* remove boiler plate mapping code to get/set fields.
* Iso message template name is the pojo name which make documentation clearer
* using a library like jreactive-8583 make easy to setup a server listener for a message type
* it provides a higher abstraction by hiding all the complex implementation of the ISO 8583 Spec
...

### Limitation
* does not include yet CompositeField (contributions welcome), have some ideas but not implemented yet.

### Status
* Work in progress. In my limited scenario, it does work as expected. I wouldn't pretend at this stage covering all scenarios border-line or not.
* more tests to be added

### Show me the code!

A round trip is provided in the unit test `com.solab.iso8583.pojo.TestPojoIsoMessage#testRoundTrip`.
Unit Test provides a simple scenario.
In a nutshell a simplified implementation will be as below:

#### The pojo
```java
import java.util.Date;
import com.solab.iso8583.IsoType;
import com.solab.iso8583.annotation.*;

@Iso8583(type=0x800)
public class NetworkMgmtRequest {

	protected String bogus;

	@Iso8583Field(index=7, type=IsoType.DATE10)
	protected Date dateTransaction;

	@Iso8583Field(index=11, type=IsoType.NUMERIC, length=6)
	protected Number systemTraceAuditNumber;


	@Iso8583Field(index=70, type=IsoType.NUMERIC, length=3)
	protected Number codeInformationNetwork;

   //constructor/getters/setters omitted for brevity
  //see com.solab.iso8583.pojo.NetworkMgmtRequest
```

#### encoding a message
```java
MessageFactory<IsoMessage> messageFactory = ConfigParser.createFromPojo(NetworkMgmtRequest.class);
IsoMessage iso = messageFactory.newMessage(new NetworkMgmtRequest(new GregorianCalendar(2000, 1, 1, 1 ,1, 1).getTime(), 999999, 1));
String isoStr = iso.debugString();
```

#### decoding a message
```java
IsoMessage iso = messageFactory.parseMessage(isoStr.getBytes(), 0);
NetworkMgmtRequest nmr = messageFactory.parseMessage(iso, NetworkMgmtRequest.class);
```

Are you fine with this improvement or do you think it should move to a specific fork?
I limited changes to original code as much as possible to keep XML backward compatibility, and try to blend as close as possible to the current implementation.
