### PR TITLE
TimeZone adjustments

### DIFF
--- a/src/main/java/com/solab/iso8583/parse/Date10ParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/Date10ParseInfo.java
@@ -18,14 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 package com.solab.iso8583.parse;
 
+import com.solab.iso8583.CustomField;
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoValue;
+
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
-
-import com.solab.iso8583.CustomField;
-import com.solab.iso8583.IsoType;
-import com.solab.iso8583.IsoValue;
 
 /** This class is used to parse fields of type DATE10.
  * 
@@ -71,7 +71,7 @@ public class Date10ParseInfo extends DateTimeParseInfo {
             cal.setTimeZone(tz);
         }
 		adjustWithFutureTolerance(cal);
-		return new IsoValue<>(type, cal.getTime(), null);
+		return createIsoValue(cal.getTime());
 	}
 
 	@Override

--- a/src/main/java/com/solab/iso8583/parse/Date12ParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/Date12ParseInfo.java
@@ -63,7 +63,7 @@ public class Date12ParseInfo extends DateTimeParseInfo {
             cal.setTimeZone(tz);
         }
    		adjustWithFutureTolerance(cal);
-   		return new IsoValue<>(type, cal.getTime(), null);
+        return createIsoValue(cal.getTime());
    	}
 
    	@Override

--- a/src/main/java/com/solab/iso8583/parse/Date14ParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/Date14ParseInfo.java
@@ -57,7 +57,7 @@ public class Date14ParseInfo extends DateTimeParseInfo {
             cal.setTimeZone(tz);
         }
    		adjustWithFutureTolerance(cal);
-   		return new IsoValue<>(type, cal.getTime(), null);
+        return createIsoValue(cal.getTime());
    	}
 
    	@Override

--- a/src/main/java/com/solab/iso8583/parse/Date4ParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/Date4ParseInfo.java
@@ -18,14 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 package com.solab.iso8583.parse;
 
+import com.solab.iso8583.CustomField;
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoValue;
+
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
-
-import com.solab.iso8583.CustomField;
-import com.solab.iso8583.IsoType;
-import com.solab.iso8583.IsoValue;
 
 /** This class is used to parse fields of type DATE4.
  * 
@@ -66,7 +66,7 @@ public class Date4ParseInfo extends DateTimeParseInfo {
             cal.setTimeZone(tz);
         }
 		Date10ParseInfo.adjustWithFutureTolerance(cal);
-		return new IsoValue<>(type, cal.getTime(), null);
+		return createIsoValue(cal.getTime());
 	}
 
 	@Override

--- a/src/main/java/com/solab/iso8583/parse/DateExpParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/DateExpParseInfo.java
@@ -18,14 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 package com.solab.iso8583.parse;
 
+import com.solab.iso8583.CustomField;
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoValue;
+
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
-
-import com.solab.iso8583.CustomField;
-import com.solab.iso8583.IsoType;
-import com.solab.iso8583.IsoValue;
 
 /** This class is used to parse fields of type DATE_EXP.
  * 
@@ -67,7 +67,7 @@ public class DateExpParseInfo extends DateTimeParseInfo {
         if (tz != null) {
             cal.setTimeZone(tz);
         }
-		return new IsoValue<>(type, cal.getTime(), null);
+		return createIsoValue(cal.getTime());
 	}
 
 	@Override

--- a/src/main/java/com/solab/iso8583/parse/DateTimeParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/DateTimeParseInfo.java
@@ -1,8 +1,10 @@
 package com.solab.iso8583.parse;
 
 import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoValue;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.TimeZone;
 
 /**
@@ -27,8 +29,17 @@ public abstract class DateTimeParseInfo extends FieldParseInfo {
     public void setTimeZone(TimeZone value) {
         tz = value;
     }
+
     public TimeZone getTimeZone() {
         return tz;
+    }
+
+    protected IsoValue<Date> createIsoValue(Date date) {
+        IsoValue<Date> value = new IsoValue<>(type, date, null);
+        value.setTimeZone(getTimeZone());
+        value.setCharacterEncoding(getCharacterEncoding());
+
+        return value;
     }
 
     public static void adjustWithFutureTolerance(Calendar cal) {

--- a/src/main/java/com/solab/iso8583/parse/TimeParseInfo.java
+++ b/src/main/java/com/solab/iso8583/parse/TimeParseInfo.java
@@ -18,14 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 package com.solab.iso8583.parse;
 
+import com.solab.iso8583.CustomField;
+import com.solab.iso8583.IsoType;
+import com.solab.iso8583.IsoValue;
+
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
-
-import com.solab.iso8583.CustomField;
-import com.solab.iso8583.IsoType;
-import com.solab.iso8583.IsoValue;
 
 /** This class is used to parse TIME fields.
  * 
@@ -88,7 +88,7 @@ public class TimeParseInfo extends DateTimeParseInfo {
         if (tz != null) {
             cal.setTimeZone(tz);
         }
-		return new IsoValue<Date>(type, cal.getTime(), null);
+		return createIsoValue(cal.getTime());
 	}
 
 }

--- a/src/test/java/com/solab/iso8583/TestFormats.java
+++ b/src/test/java/com/solab/iso8583/TestFormats.java
@@ -1,11 +1,11 @@
 package com.solab.iso8583;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.TimeZone;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 /** Tests formatting of certain IsoTypes.
  * 
@@ -17,12 +17,26 @@ public class TestFormats {
 
 	@Test
 	public void testDateFormats() {
-		Assert.assertEquals("0125213456", IsoType.DATE10.format(date, null));
-        Assert.assertEquals("0125", IsoType.DATE4.format(date, null));
-        Assert.assertEquals("7301", IsoType.DATE_EXP.format(date, null));
-        Assert.assertEquals("213456", IsoType.TIME.format(date, null));
-        Assert.assertEquals("730125213456", IsoType.DATE12.format(date, null));
-		Assert.assertEquals("19730125213456", IsoType.DATE14.format(date, null));
+		TimeZone systemTimeZone = TimeZone.getDefault();
+
+		String expected = IsoType.DATE10.format(date, systemTimeZone);
+		Assert.assertEquals(expected, IsoType.DATE10.format(date, null));
+
+		expected = IsoType.DATE4.format(date, systemTimeZone);
+        Assert.assertEquals(expected, IsoType.DATE4.format(date, null));
+
+        expected = IsoType.DATE_EXP.format(date, systemTimeZone);
+        Assert.assertEquals(expected, IsoType.DATE_EXP.format(date, null));
+
+		expected = IsoType.TIME.format(date, systemTimeZone);
+        Assert.assertEquals(expected, IsoType.TIME.format(date, null));
+
+        expected = IsoType.DATE12.format(date, null);
+        Assert.assertEquals(expected, IsoType.DATE12.format(date, null));
+
+        expected = IsoType.DATE14.format(date, null);
+		Assert.assertEquals(expected, IsoType.DATE14.format(date, null));
+
         //Now with GMT
         TimeZone gmt = TimeZone.getTimeZone("GMT");
         Assert.assertEquals("0126033456", IsoType.DATE10.format(date, gmt));

--- a/src/test/java/com/solab/iso8583/TestParsing.java
+++ b/src/test/java/com/solab/iso8583/TestParsing.java
@@ -119,6 +119,7 @@ public class TestParsing {
         Assert.assertEquals(25, cal.get(Calendar.DATE));
         Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
 		Assert.assertEquals("debug string should match", "060002000000000000000125213456", m.debugString());
+		Assert.assertNull("Expect default timezone as null", m.getAt(7).getTimeZone());
 
         mf.setTimezoneForParseGuide(0x600, 7, TimeZone.getTimeZone("GMT"));
         m = mf.parseMessage("060002000000000000000125213456".getBytes(), 0);
@@ -128,6 +129,7 @@ public class TestParsing {
         Assert.assertEquals(Calendar.JANUARY, cal.get(Calendar.MONTH));
         Assert.assertEquals(25, cal.get(Calendar.DATE));
         Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(TimeZone.getTimeZone("GMT"), m.getAt(7).getTimeZone());
 
         mf.setTimezoneForParseGuide(0x600, 7, TimeZone.getTimeZone("GMT+0100"));
         m = mf.parseMessage("060002000000000000000125213456".getBytes(), 0);
@@ -137,6 +139,6 @@ public class TestParsing {
         Assert.assertEquals(Calendar.JANUARY, cal.get(Calendar.MONTH));
         Assert.assertEquals(25, cal.get(Calendar.DATE));
         Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
+		Assert.assertEquals(TimeZone.getTimeZone("GMT+0100"), m.getAt(7).getTimeZone());
     }
-
 }

--- a/src/test/java/com/solab/iso8583/TestParsing.java
+++ b/src/test/java/com/solab/iso8583/TestParsing.java
@@ -1,5 +1,10 @@
 package com.solab.iso8583;
 
+import com.solab.iso8583.parse.NumericParseInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
@@ -7,12 +12,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
-
-import com.solab.iso8583.codecs.CompositeField;
-import com.solab.iso8583.parse.NumericParseInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /** Test that parsing invalid messages is properly handled.
  * 
@@ -120,20 +119,24 @@ public class TestParsing {
         Assert.assertEquals(25, cal.get(Calendar.DATE));
         Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
 		Assert.assertEquals("debug string should match", "060002000000000000000125213456", m.debugString());
+
         mf.setTimezoneForParseGuide(0x600, 7, TimeZone.getTimeZone("GMT"));
         m = mf.parseMessage("060002000000000000000125213456".getBytes(), 0);
         f = m.getObjectValue(7);
+		cal.setTimeZone(TimeZone.getTimeZone("GMT"));
         cal.setTime(f);
         Assert.assertEquals(Calendar.JANUARY, cal.get(Calendar.MONTH));
         Assert.assertEquals(25, cal.get(Calendar.DATE));
-        Assert.assertEquals(15, cal.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
+
         mf.setTimezoneForParseGuide(0x600, 7, TimeZone.getTimeZone("GMT+0100"));
         m = mf.parseMessage("060002000000000000000125213456".getBytes(), 0);
         f = m.getObjectValue(7);
+		cal.setTimeZone(TimeZone.getTimeZone("GMT+0100"));
         cal.setTime(f);
         Assert.assertEquals(Calendar.JANUARY, cal.get(Calendar.MONTH));
         Assert.assertEquals(25, cal.get(Calendar.DATE));
-        Assert.assertEquals(14, cal.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(21, cal.get(Calendar.HOUR_OF_DAY));
     }
 
 }


### PR DESCRIPTION
Tests were modified to allow testing in any local TimeZone when running tests. This should allow everyone to test locally without error.

When parsing messages, the TimeZone was using the default local TimeZone. I believe this should match the parse TimeZone to avoid confusion when viewing the log. This will also allow MessageFactory response calls to contain the same TimeZone as the original message.